### PR TITLE
vendor: omni: utils: Bring back WallpaperPicker to the aosp forked list

### DIFF
--- a/utils/aosp-forked-list
+++ b/utils/aosp-forked-list
@@ -63,6 +63,7 @@ packages/apps/PhoneCommon
 packages/apps/QuickSearchBox
 packages/apps/Settings
 packages/apps/UnifiedEmail
+packages/apps/WallpaperPicker
 packages/inputmethods/LatinIME
 packages/providers/DownloadProvider
 packages/providers/MediaProvider


### PR DESCRIPTION
Change-Id: Ic27aad28f50e15c29583ade36e43612caa7ade7d
Signed-off-by: Humberto Borba <humberos@gmail.com>