### PR TITLE
omni: add mount debugfs to init.omni.rc

### DIFF
--- a/prebuilt/etc/init.local.rc
+++ b/prebuilt/etc/init.local.rc
@@ -1,5 +1,9 @@
 # Omni Extras
 
+on early-init
+    mount debugfs debugfs /sys/kernel/debug
+    chmod 0755 /sys/kernel/debug
+
 on init
     export TERMINFO /system/etc/terminfo
     export TERM linux


### PR DESCRIPTION
better safe then sorry if a device forgets it

Change-Id: Ic4256afbbaa4da331b583f16eadbbd97a5ad27e1