### PR TITLE
omni: sepolicy: allow platform_app syslog_read

### DIFF
--- a/config/packages.mk
+++ b/config/packages.mk
@@ -19,7 +19,8 @@ PRODUCT_PACKAGES += \
     audio_effects.conf \
     libcyanogen-dsp \
     Phonograph \
-    Turbo
+    Turbo \
+    MatLog
 
 PRODUCT_PACKAGES += \
     CellBroadcastReceiver

--- a/sepolicy/platform_app.te
+++ b/sepolicy/platform_app.te
@@ -14,3 +14,5 @@ allow platform_app fuse_device:dir { rw_dir_perms create_dir_perms };
 allow platform_app fuse_device:file { rw_file_perms create_file_perms };
 allow platform_app fuse_device:filesystem getattr;
 
+# MatLog calls dmesg
+allow platform_app kernel:system syslog_read;


### PR DESCRIPTION
for MatLog collecting dmesg
and add MatLog to apps list

Change-Id: I424d0904eccefdeac43a9322f1e8f5d9d4c49902